### PR TITLE
Increasing environment variables for app container

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,6 @@ Resources:
         AmbassadorEnvironment2Value: '' # optional
         AmbassadorEnvironment3Key: '' # optional
         AmbassadorEnvironment3Value: '' # optional
-        AmbassadorEnvironment4Key: '' # optional
-        AmbassadorEnvironment4Value: '' # optional
-        AmbassadorEnvironment5Key: '' # optional
-        AmbassadorEnvironment5Value: '' # optional
-        AmbassadorEnvironment6Key: '' # optional
-        AmbassadorEnvironment6Value: '' # optional
         AppImage: 'widdix/hello:v1' # optional
         AppPort: '80' # optional
         AppEnvironment1Key: '' # optional
@@ -54,6 +48,12 @@ Resources:
         AppEnvironment2Value: '' # optional
         AppEnvironment3Key: '' # optional
         AppEnvironment3Value: '' # optional
+        AppEnvironment4Key: '' # optional
+        AppEnvironment4Value: '' # optional
+        AppEnvironment5Key: '' # optional
+        AppEnvironment5Value: '' # optional
+        AppEnvironment6Key: '' # optional
+        AppEnvironment6Value: '' # optional
         SidecarImage: '' # optional
         SidecarPort: '9000' # optional
         SidecarEnvironment1Key: '' # optional
@@ -200,48 +200,6 @@ Resources:
       <td></td>
     </tr>
     <tr>
-      <td>AmbassadorEnvironment4Key</td>
-      <td>Environment variable 4 key for ambassador container</td>
-      <td></td>
-      <td>no</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>AmbassadorEnvironment4Value</td>
-      <td>Environment variable 4 value for ambassador container</td>
-      <td></td>
-      <td>no</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>AmbassadorEnvironment5Key</td>
-      <td>Environment variable 5 key for ambassador container</td>
-      <td></td>
-      <td>no</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>AmbassadorEnvironment5Value</td>
-      <td>Environment variable 5 value for ambassador container</td>
-      <td></td>
-      <td>no</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>AmbassadorEnvironment6Key</td>
-      <td>Environment variable 6 key for ambassador container</td>
-      <td></td>
-      <td>no</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>AmbassadorEnvironment6Value</td>
-      <td>Environment variable 6 value for ambassador container</td>
-      <td></td>
-      <td>no</td>
-      <td></td>
-    </tr>
-    <tr>
       <td>AppImage</td>
       <td>The Docker image to use for the app container. You can use images in the Docker Hub registry or specify other repositories (repository-url/image:tag)</td>
       <td>widdix/hello:v1</td>
@@ -293,6 +251,48 @@ Resources:
     <tr>
       <td>AppEnvironment3Value</td>
       <td>Environment variable 3 value for app container</td>
+      <td></td>
+      <td>no</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>AppEnvironment4Key</td>
+      <td>Environment variable 4 key for app container</td>
+      <td></td>
+      <td>no</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>AppEnvironment4Value</td>
+      <td>Environment variable 4 value for app container</td>
+      <td></td>
+      <td>no</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>AppEnvironment5Key</td>
+      <td>Environment variable 5 key for app container</td>
+      <td></td>
+      <td>no</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>AppEnvironment5Value</td>
+      <td>Environment variable 5 value for app container</td>
+      <td></td>
+      <td>no</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>AppEnvironment6Key</td>
+      <td>Environment variable 6 key for app container</td>
+      <td></td>
+      <td>no</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>AppEnvironment6Value</td>
+      <td>Environment variable 6 value for app container</td>
       <td></td>
       <td>no</td>
       <td></td>

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ Resources:
         AmbassadorEnvironment2Value: '' # optional
         AmbassadorEnvironment3Key: '' # optional
         AmbassadorEnvironment3Value: '' # optional
+        AmbassadorEnvironment4Key: '' # optional
+        AmbassadorEnvironment4Value: '' # optional
+        AmbassadorEnvironment5Key: '' # optional
+        AmbassadorEnvironment5Value: '' # optional
+        AmbassadorEnvironment6Key: '' # optional
+        AmbassadorEnvironment6Value: '' # optional
         AppImage: 'widdix/hello:v1' # optional
         AppPort: '80' # optional
         AppEnvironment1Key: '' # optional
@@ -189,6 +195,48 @@ Resources:
     <tr>
       <td>AmbassadorEnvironment3Value</td>
       <td>Environment variable 3 value for ambassador container</td>
+      <td></td>
+      <td>no</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>AmbassadorEnvironment4Key</td>
+      <td>Environment variable 4 key for ambassador container</td>
+      <td></td>
+      <td>no</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>AmbassadorEnvironment4Value</td>
+      <td>Environment variable 4 value for ambassador container</td>
+      <td></td>
+      <td>no</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>AmbassadorEnvironment5Key</td>
+      <td>Environment variable 5 key for ambassador container</td>
+      <td></td>
+      <td>no</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>AmbassadorEnvironment5Value</td>
+      <td>Environment variable 5 value for ambassador container</td>
+      <td></td>
+      <td>no</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>AmbassadorEnvironment6Key</td>
+      <td>Environment variable 6 key for ambassador container</td>
+      <td></td>
+      <td>no</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>AmbassadorEnvironment6Value</td>
+      <td>Environment variable 6 value for ambassador container</td>
       <td></td>
       <td>no</td>
       <td></td>

--- a/module.yml
+++ b/module.yml
@@ -587,7 +587,7 @@ Outputs:
   ModuleId:
     Value: 'fargate-service'
   ModuleVersion:
-    Value: '1.1.1'
+    Value: '1.2.0'
   StackName:
     Value: !Ref 'AWS::StackName'
   TaskRoleArn:

--- a/module.yml
+++ b/module.yml
@@ -114,6 +114,30 @@ Parameters:
     Description: 'Optional environment variable 3 value for app container.'
     Type: String
     Default: ''
+  AppEnvironment4Key:
+    Description: 'Optional environment variable 4 key for app container.'
+    Type: String
+    Default: ''
+  AppEnvironment4Value:
+    Description: 'Optional environment variable 4 value for app container.'
+    Type: String
+    Default: ''
+  AppEnvironment5Key:
+    Description: 'Optional environment variable 5 key for app container.'
+    Type: String
+    Default: ''
+  AppEnvironment5Value:
+    Description: 'Optional environment variable 5 value for app container.'
+    Type: String
+    Default: ''
+  AppEnvironment6Key:
+    Description: 'Optional environment variable 6 key for app container.'
+    Type: String
+    Default: ''
+  AppEnvironment6Value:
+    Description: 'Optional environment variable 6 value for app container.'
+    Type: String
+    Default: ''
   SidecarImage:
     Description: 'Optional Docker image to use for the sidecar container (https://docs.microsoft.com/en-us/azure/architecture/patterns/sidecar). You can use images in the Docker Hub registry or specify other repositories (repository-url/image:tag).'
     Type: String
@@ -287,6 +311,9 @@ Conditions:
   HasAppEnvironment1Key: !Not [!Equals [!Ref AppEnvironment1Key, '']]
   HasAppEnvironment2Key: !Not [!Equals [!Ref AppEnvironment2Key, '']]
   HasAppEnvironment3Key: !Not [!Equals [!Ref AppEnvironment3Key, '']]
+  HasAppEnvironment4Key: !Not [!Equals [!Ref AppEnvironment4Key, '']]
+  HasAppEnvironment5Key: !Not [!Equals [!Ref AppEnvironment5Key, '']]
+  HasAppEnvironment6Key: !Not [!Equals [!Ref AppEnvironment6Key, '']]
   HasAmbassadorImage: !Not [!Equals [!Ref AmbassadorImage, '']]
   HasAmbassadorEnvironment1Key: !Not [!Equals [!Ref AmbassadorEnvironment1Key, '']]
   HasAmbassadorEnvironment2Key: !Not [!Equals [!Ref AmbassadorEnvironment2Key, '']]
@@ -368,6 +395,9 @@ Resources:
         - !If [HasAppEnvironment1Key, {Name: !Ref AppEnvironment1Key, Value: !Ref AppEnvironment1Value}, !Ref 'AWS::NoValue']
         - !If [HasAppEnvironment2Key, {Name: !Ref AppEnvironment2Key, Value: !Ref AppEnvironment2Value}, !Ref 'AWS::NoValue']
         - !If [HasAppEnvironment3Key, {Name: !Ref AppEnvironment3Key, Value: !Ref AppEnvironment3Value}, !Ref 'AWS::NoValue']
+        - !If [HasAppEnvironment4Key, {Name: !Ref AppEnvironment4Key, Value: !Ref AppEnvironment4Value}, !Ref 'AWS::NoValue']
+        - !If [HasAppEnvironment5Key, {Name: !Ref AppEnvironment5Key, Value: !Ref AppEnvironment5Value}, !Ref 'AWS::NoValue']
+        - !If [HasAppEnvironment6Key, {Name: !Ref AppEnvironment6Key, Value: !Ref AppEnvironment6Value}, !Ref 'AWS::NoValue']
       - !If
         - HasSidecarImage
         - Name: sidecar

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cfn-modules/fargate-service",
-  "version": "1.2.1",
+  "version": "1.2.0",
   "description": "Application load balancer.",
   "author": "Michael Wittig <michael@widdix.de>",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cfn-modules/fargate-service",
-  "version": "1.1.1",
+  "version": "1.2.1",
   "description": "Application load balancer.",
   "author": "Michael Wittig <michael@widdix.de>",
   "license": "Apache-2.0",


### PR DESCRIPTION
Currently, the number of environment variables is limited to 3. We are limited by the maximum CloudFormation parameters. Nevertheless, I'd like to increase the number of environment variables for the app container to 6. The ambassador and sidecar container typically need less environment variables in my opinion, Therefore, I would not add additional environment variables for those containers.